### PR TITLE
Make the code in copycat-core compile on java1.7

### DIFF
--- a/copycat-core/src/main/java/net/kuujo/copycat/Leader.java
+++ b/copycat-core/src/main/java/net/kuujo/copycat/Leader.java
@@ -509,7 +509,7 @@ class Leader extends BaseState implements Observer {
     /**
      * Sends an append entries request to the follower.
      */
-    private void doAppendEntries(long prevIndex, Entry prevEntry, List<Entry> entries) {
+    private void doAppendEntries(final long prevIndex, Entry prevEntry, final List<Entry> entries) {
       final long commitIndex = context.getCommitIndex();
       if (logger.isLoggable(Level.FINER)) {
         if (!entries.isEmpty()) {

--- a/copycat-core/src/main/java/net/kuujo/copycat/StateMachineExecutor.java
+++ b/copycat-core/src/main/java/net/kuujo/copycat/StateMachineExecutor.java
@@ -87,7 +87,7 @@ class StateMachineExecutor {
           }
           CommandHolder holder = commands.get(name);
           if (holder == null) {
-            holder = new CommandHolder(stateMachine, new GenericCommand(name, command.type()), new ArrayList<>());
+            holder = new CommandHolder(stateMachine, new GenericCommand(name, command.type()), new ArrayList<Method>());
             commands.put(name, holder);
           }
           holder.methods.add(method);


### PR DESCRIPTION

As far as I can tell, the java-1.7 branch not only is behind the master, but it doesn't even compile.

Should I even consider using it?

